### PR TITLE
Removes Postgresql already installed warning.

### DIFF
--- a/commands
+++ b/commands
@@ -385,7 +385,6 @@ case "$1" in
   psql:install)
     if [[ -d "$HOME" ]]; then
       migrate
-      echo "Postgresql data already exist in "$HOME", installation aborded "
     fi
 
     if [[ ! -d "$HOME" ]]; then


### PR DESCRIPTION
Hi Ohardy,

I would argue this message is unnecessary, it runs every time one installs a new plugin. And there's a typo in there ;)

What do you think?

Great plugin BTW, the most feature comprehensive by far.