### PR TITLE
Truncate to 16 is very impractical for our usecase

### DIFF
--- a/commands
+++ b/commands
@@ -79,7 +79,7 @@ db_url() {
 }
 
 database_name() {
-  echo "$1" | cut -c 1-16 | tr .- _
+  echo "$1" | cut -c 1-64 | tr .- _
 }
 
 migrate() {


### PR DESCRIPTION
Sadly, we have quite long app names and thus the truncation of the database name is actually hindering us.